### PR TITLE
cm/add-homepage-buttons

### DIFF
--- a/components/Home/HomeSection.tsx
+++ b/components/Home/HomeSection.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Button } from "@mui/material";
 import useStyles from "./styles";
 import { ParticleBackground } from "./ui/Particles";
+
+const RESUME_URL = "https://drive.google.com/file/d/10OPCj_eNCQS5opKsOtaKsewGcn31BUdY/view?usp=sharing"
 
 export const HomeSection = () => {
   const { classes } = useStyles();
@@ -16,6 +18,10 @@ export const HomeSection = () => {
         <Typography className={classes.subtitle}>
           A Creative, Passionate, Software Engineer
         </Typography>
+        <Box className={classes.buttonContainer}>
+          <Button className={classes.resumeButton} onClick={() => window.open(RESUME_URL, '_blank')}>Download Resume</Button>
+          <Button className={classes.contactButton} href="#contact">Contact Me</Button>
+        </Box>
       </Box>
       {/* Interactive background  */}
       <ParticleBackground />

--- a/components/Home/styles.tsx
+++ b/components/Home/styles.tsx
@@ -1,5 +1,15 @@
 import { makeStyles } from "tss-react/mui";
 import { mozillaText } from "@/app/ui/fonts";
+import { Theme } from '@mui/material/styles';
+
+const getCommonButtonStyles = (theme: Theme) =>{
+  return {
+    fontFamily: mozillaText.style.fontFamily,
+    padding: theme.spacing(1, 2),
+    borderRadius: "50px",
+    fontWeight: 700
+  }
+}
 
 const useStyles = makeStyles()((theme) => ({
   body: {
@@ -34,10 +44,29 @@ const useStyles = makeStyles()((theme) => ({
   subtitle: {
     fontFamily: mozillaText.style.fontFamily,
     color: "#F1E3D3",
-    fontSize: "1.5rem",
+    fontSize: "1.75rem",
     [theme.breakpoints.down("sm")]: {
-      fontSize: "1rem",
+      fontSize: "1.05rem",
     },
+  },
+  resumeButton: {
+    color: "#F1E3D3",
+    backgroundColor: "#720026",
+    ...getCommonButtonStyles(theme)
+  },
+  contactButton: {
+    backgroundColor: "#F1E3D3",
+    color: "#720026",
+    ...getCommonButtonStyles(theme)
+  },
+  buttonContainer: {
+    display: "flex",
+    gap: theme.spacing(5),
+    justifyContent: "center",
+    alignContent: "center",
+    width: "100vw",
+    marginTop: theme.spacing(2),
+
   },
 }));
 export default useStyles;


### PR DESCRIPTION
### Changes made
- Add 2 buttons to the homepage for downloading my resume and to send them to the contact page

### Testing
- [x] Home page should have 2 new buttons, 'Downlad resume' and 'Contact'
- [x] Download resume should send you to a downloadable google drive link to my resume
- [x] Contact should send you to the contact page
- [x] should be mobile responsive 

### Notes


### Screenshots/Recordings
<img width="1728" height="986" alt="Screenshot 2025-08-11 at 9 06 52 PM" src="https://github.com/user-attachments/assets/c89236b4-5f9f-40c6-844e-8ffcad0936aa" />

<img width="391" height="831" alt="Screenshot 2025-08-11 at 9 07 07 PM" src="https://github.com/user-attachments/assets/14951c1f-2aeb-4977-b990-e60b48c58724" />
